### PR TITLE
Fix: 接頭辞を指定した際にRviz上でうまく表示できなくなる不具合を解消

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,8 +24,6 @@ OPERA対応クローラダンプIC120の土木研究所公開ROS2パッケージ
   $ colcon build && source install/setup.bash
   ```
 
-## kakaaaaaa
-
 ## 含有するサブパッケージ
 ### ic120_bringup:
 - ic120の実機を動作させる際に必要なノード群を一括起動するためのlaunch用のサブパッケージ


### PR DESCRIPTION
ic120_ros2ではoperasim上のic120を操作するlaunch.pyファイルを起動する際に、以下のとおり接頭辞を付与することができました。

ros2 launch ic120_unity ic120_standby_ekf.launch.py common_prefix:=[接頭辞(例：ic120_1, ic120_2, ...)]

しかし、RVizファイルもそれに合わせて更新する設定になっていなかったため、接頭辞を指定した際にうまく表示できなくなる不具合がありました。これを解消しました。